### PR TITLE
使得think-worker的http协议支持识别css和js的mimeType;

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -228,7 +228,7 @@ class Http extends Server
     /**
      * getTextMimeType
      * 通过文件名获取css，js等文本的mimeType
-     * @param mixed $filename 
+     * @param mixed $filename
      * @return mixed
      */
     public function getTextMimeType($filename)

--- a/src/Http.php
+++ b/src/Http.php
@@ -219,7 +219,7 @@ class Http extends Server
         $mime_type = finfo_file($finfo, $filename);
 
         if($mime_type === 'text/plain'){
-            $mimeType = $this->getTextMimeType($filename);
+            $mime_type = $this->getTextMimeType($filename);
         }
 
         return $mime_type;
@@ -243,6 +243,7 @@ class Http extends Server
             'jad'=>'text/vnd.sun.j2me.app-descriptor',
             'wml'=>'text/vnd.wap.wml',
             'htc'=>'text/x-component',
+            'js'=>'application/x-javascript'
         ];
 
         $ext_name = explode('.',$filename);

--- a/src/Http.php
+++ b/src/Http.php
@@ -229,9 +229,10 @@ class Http extends Server
      * getTextMimeType
      * 通过文件名获取css，js等文本的mimeType
      * @param mixed $filename 
-     * @return mixed 
+     * @return mixed
      */
-    public function getTextMimeType($filename){
+    public function getTextMimeType($filename)
+    {
         $mime_type_ext = [
             'html'=>'text/html',
             'htm'=>'text/html',
@@ -246,7 +247,7 @@ class Http extends Server
             'js'=>'application/x-javascript'
         ];
 
-        $ext_name = explode('.',$filename);
+        $ext_name = explode('.', $filename);
 
         $ext_name = array_pop($ext_name);
 

--- a/src/Http.php
+++ b/src/Http.php
@@ -216,7 +216,45 @@ class Http extends Server
     {
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
 
-        return finfo_file($finfo, $filename);
+        $mime_type = finfo_file($finfo, $filename);
+
+        if($mime_type === 'text/plain'){
+            $mimeType = $this->getTextMimeType($filename);
+        }
+
+        return $mime_type;
+    }
+
+    /**
+     * getTextMimeType
+     * 通过文件名获取css，js等文本的mimeType
+     * @param mixed $filename 
+     * @return mixed 
+     */
+    public function getTextMimeType($filename){
+        $mime_type_ext = [
+            'html'=>'text/html',
+            'htm'=>'text/html',
+            'shtm'=>'text/html',
+            'css'=>'text/css',
+            'xml'=>'text/xml',
+            'mml'=>'text/mathml',
+            'txt'=>'text/plain',
+            'jad'=>'text/vnd.sun.j2me.app-descriptor',
+            'wml'=>'text/vnd.wap.wml',
+            'htc'=>'text/x-component',
+        ];
+
+        $ext_name = explode('.',$filename);
+
+        $ext_name = array_pop($ext_name);
+
+        if(isset($mime_type_ext[$ext_name])){
+            return $mime_type_ext[$ext_name];
+        }else{
+            return 'text/plain';
+        }
+
     }
 
     /**


### PR DESCRIPTION

使得think-worker的http协议支持识别css和js的mimeType; 

finfo_file不能将css文件识别为text/css,
当识别的类型是text/plain时,根据文件扩展名识别mimeType.