### PR TITLE
解决HTTP数据传输无法获取，修复文件MimeType识别兼容性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+/.idea
+/.vscode
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "workerman/workerman": "^3.5.0",
         "workerman/gateway-worker": "^3.0.0",
         "topthink/think-installer": "^2.0",
-        "topthink/framework": "^5.1.18"
+        "topthink/framework": "^5.1.18",
+        "ext-fileinfo": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "workerman/workerman": "^3.3.0",
+        "workerman/workerman": "^3.5.0",
         "workerman/gateway-worker": "^3.0.0",
         "topthink/think-installer": "^2.0",
         "topthink/framework": "^5.1.18"

--- a/src/Application.php
+++ b/src/Application.php
@@ -40,7 +40,9 @@ class Application extends App
 
             $pathinfo = ltrim(strpos($_SERVER['REQUEST_URI'], '?') ? strstr($_SERVER['REQUEST_URI'], '?', true) : $_SERVER['REQUEST_URI'], '/');
 
-            $this->request->setPathinfo($pathinfo);
+            $this->request
+                ->setPathinfo($pathinfo)
+                ->withInput($GLOBALS['HTTP_RAW_REQUEST_DATA']);
 
             if ($this->config->get('session.auto_start')) {
                 WorkerHttp::sessionStart();


### PR DESCRIPTION
- 修复Http提交数据无法获取
    - 使用 `$GLOBALS['HTTP_RAW_REQUEST_DATA']` 解决无法从 `php://input` 获取数据问题
- 修复文件MimeType识别兼容性
    - 使用 Workerman 内置类型匹配方案